### PR TITLE
feat: #58 Post API 추가

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,17 +1,17 @@
 import axios from 'axios';
 
 const request = axios.create({
-    baseURL: process.env.REACT_APP_API_ENDPOINT,
-    headers: {
-        'Content-Type': 'application/json',
-        Accept: '*/*',
-    },
+  baseURL: process.env.REACT_APP_API_ENDPOINT,
+  headers: {
+    'Content-Type': 'application/json',
+    Accept: '*/*',
+  },
 });
 
-const AUTH_TOKEN = localStorage.getItem('AUTH_TOKEN')
+const AUTH_TOKEN = localStorage.getItem('AUTH_TOKEN');
 
-if(AUTH_TOKEN) {
-    request.defaults.headers.common['Authorization'] = AUTH_TOKEN
+if (AUTH_TOKEN) {
+  request.defaults.headers.common['Authorization'] = AUTH_TOKEN;
 }
 
-export default request
+export default request;

--- a/src/api/post1/index.ts
+++ b/src/api/post1/index.ts
@@ -1,0 +1,158 @@
+import { AxiosResponse } from 'axios';
+import request from '../index';
+
+interface getChannelPost {
+  (
+    channelId: string,
+    offset: number,
+    limit: number
+  ): Promise<AxiosResponse<Post[]> | undefined>;
+}
+
+interface getUserPost {
+  (
+    authorId: string,
+    offset: number,
+    limit: number
+  ): Promise<AxiosResponse<Post[]> | undefined>;
+}
+
+interface readPost {
+  (postId: string): Promise<AxiosResponse<Post> | undefined>;
+}
+/* reponse 모델 설정 */
+interface Post {
+  likes: Like[];
+  comments: Comment[];
+  _id: string;
+  image?: string;
+  imagePublicId?: string;
+  title: string;
+  channel: Channel;
+  author: User;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface User {
+  coverImage: string;
+  image: string;
+  role: string;
+  emailVerified: boolean;
+  banned: boolean;
+  isOnline: boolean;
+  posts: Post[];
+  likes: Like[];
+  comments: string[];
+  followers: [];
+  following: [
+    {
+      _id: string;
+      user: string;
+      follower: string;
+      createdAt: string;
+      updatedAt: string;
+      __v: number;
+    },
+  ];
+  notifications: Notification[];
+  messages: Message[];
+  _id: string;
+  fullName: string;
+  email: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Like {
+  _id: string;
+  user: string;
+  post: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Comment {
+  _id: string;
+  comment: string;
+  author: User;
+  post: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Channel {
+  authRequired: boolean;
+  posts: string[];
+  _id: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Message {
+  _id: string;
+  message: string;
+  sender: User;
+  receiver: User;
+  seen: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// 특정 채널의 포스트 목록 불러오기
+export const getChannelPost: getChannelPost = async (
+  channelId,
+  offset,
+  limit
+) => {
+  try {
+    const response = await request.get(`/posts/channel/${channelId}`, {
+      params: {
+        offset,
+        limit,
+      },
+    });
+
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 특정 사용자의 포스트 목록 불러오기
+export const getUserPost: getUserPost = async (authorId, offset, limit) => {
+  try {
+    const response = request.get(`/posts/author/${authorId}`, {
+      params: {
+        offset,
+        limit,
+      },
+    });
+
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 특정 채널에 포스트 작성하기
+export const writePost = async () => {
+  try {
+    await request.post('/posts/create');
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// 특정 포스트 상세 보기
+export const readPost: readPost = async (postId) => {
+  try {
+    const response = request.get(`/posts/${postId}`);
+
+    return response;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/api/post1/index.ts
+++ b/src/api/post1/index.ts
@@ -17,6 +17,14 @@ interface getUserPost {
   ): Promise<AxiosResponse<Post[]> | undefined>;
 }
 
+interface writePost {
+  (
+    title: string,
+    image: File,
+    channelId: string
+  ): Promise<AxiosResponse<void> | undefined>;
+}
+
 interface readPost {
   (postId: string): Promise<AxiosResponse<Post> | undefined>;
 }
@@ -107,52 +115,43 @@ export const getChannelPost: getChannelPost = async (
   offset,
   limit
 ) => {
-  try {
-    const response = await request.get(`/posts/channel/${channelId}`, {
-      params: {
-        offset,
-        limit,
-      },
-    });
+  const res = await request.get(`/posts/channel/${channelId}`, {
+    params: {
+      offset,
+      limit,
+    },
+  });
 
-    return response;
-  } catch (error) {
-    console.error(error);
-  }
+  return res;
 };
 
 // 특정 사용자의 포스트 목록 불러오기
 export const getUserPost: getUserPost = async (authorId, offset, limit) => {
-  try {
-    const response = request.get(`/posts/author/${authorId}`, {
-      params: {
-        offset,
-        limit,
-      },
-    });
+  const res = await request.get(`/posts/author/${authorId}`, {
+    params: {
+      offset,
+      limit,
+    },
+  });
 
-    return response;
-  } catch (error) {
-    console.error(error);
-  }
+  return res;
 };
 
 // 특정 채널에 포스트 작성하기
-export const writePost = async () => {
-  try {
-    await request.post('/posts/create');
-  } catch (error) {
-    console.error(error);
-  }
+export const writePost: writePost = async (title, image, channelId) => {
+  const formData = new FormData();
+  formData.append('title', title);
+  formData.append('image', image);
+  formData.append('channelId', channelId);
+
+  const res = await request.post('/posts/create', formData);
+
+  return res;
 };
 
 // 특정 포스트 상세 보기
 export const readPost: readPost = async (postId) => {
-  try {
-    const response = request.get(`/posts/${postId}`);
+  const res = await request.get(`/posts/${postId}`);
 
-    return response;
-  } catch (error) {
-    console.error(error);
-  }
+  return res;
 };


### PR DESCRIPTION
# 브랜치명
`feat/#58_post_api`

## 간단한 내용 설명
Post 관련 API를 추가 했습니다.

## 구현 내용
- [x] 특정 채널의 포스트 목록 불러오는 API 구현
- [x] 특정 사용자의 포스트 목록 불러오는 API 구현
- [x] 특정 채널에 포스트 작성하는 API 구현
- [x] 특정 포스트의 상세 내용 보는 API 구현

## 장애물?
TypeScript부분 구현이 맞는지 헷갈려서 어려웠습니다.

## PR 포인트
TypeScript부분과 Axios구현을 제대로 한 것인지 확인 부탁드립니다:)

## 참고 사항
없습니다.

## 궁금한 점
없습니다.

close #58 