### PR TITLE
feat: top_nav_btn 컴포넌트 구현

### DIFF
--- a/src/assets/top_nav_btn.svg
+++ b/src/assets/top_nav_btn.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="163" height="49" viewBox="0 0 163 49" fill="none">
+  <path d="M137.773 48.3898C144.215 48.3898 150.393 45.851 154.948 41.3319C159.503 36.8128 162.062 30.6836 162.062 24.2926C162.062 17.9016 159.503 11.7723 154.948 7.2532C150.393 2.73409 144.215 0.195313 137.773 0.195312H25.2233C18.7813 0.195312 12.6031 2.73409 8.04792 7.2532C3.49271 11.7723 0.933594 17.9016 0.933594 24.2926C0.933594 30.6836 3.49271 36.8128 8.04792 41.3319C12.6031 45.851 18.7813 48.3898 25.2233 48.3898H137.773Z" fill="url(#paint0_linear_125_17066)"/>
+  <defs>
+    <linearGradient id="paint0_linear_125_17066" x1="21.3271" y1="48.6461" x2="65.5793" y2="-51.986" gradientUnits="userSpaceOnUse">
+      <stop offset="0.018" stop-color="#FCCBF3"/>
+      <stop offset="0.197" stop-color="#E8CBF4"/>
+      <stop offset="0.561" stop-color="#B6CCF9"/>
+      <stop offset="1" stop-color="#72CDFF"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/components/common/TopNavBtn/index.tsx
+++ b/src/components/common/TopNavBtn/index.tsx
@@ -1,0 +1,55 @@
+import styled from '@emotion/styled';
+
+interface topNavBtnProps {
+  width?: number;
+  height?: number;
+  isActive: boolean;
+  title: string;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const ButtonWrapper = styled.button<{ isActive: boolean }>`
+  background-image: ${({ isActive }) =>
+    isActive && "url('src/assets/top_nav_btn.svg')"};
+  background-size: cover;
+  border: none;
+  outline: none;
+  flex-shrink: 0;
+  padding: 40px;
+  border-radius: 50px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: #f8fbff;
+  font-size: 23px;
+  font-family: 'ONE-Mobile-Title';
+  font-weight: 800;
+  background-color: ${({ isActive }) => isActive || '#D9E4FB'};
+  cursor: pointer;
+`;
+
+const TopNavBtn = ({
+  width = 166,
+  height = 48,
+  title,
+  isActive = false,
+  onClick,
+  ...props
+}: topNavBtnProps) => {
+  const btnStyle = {
+    width: `${width}px`,
+    height: `${height}px`,
+  };
+  return (
+    <ButtonWrapper
+      style={btnStyle}
+      isActive={isActive}
+      onClick={onClick}
+      {...props}
+    >
+      {title}
+    </ButtonWrapper>
+  );
+};
+
+export default TopNavBtn;

--- a/src/components/common/TopNavBtn/index.tsx
+++ b/src/components/common/TopNavBtn/index.tsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 interface topNavBtnProps {
   width?: number;
   height?: number;
-  isActive: boolean;
+  isActive?: boolean;
   title: string;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
 }

--- a/src/stories/TopNavBtn.stories.tsx
+++ b/src/stories/TopNavBtn.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TopNavBtn from '~/components/common/TopNavBtn';
+
+const meta: Meta<typeof TopNavBtn> = {
+  title: 'Component/TopNavBtn',
+  component: TopNavBtn,
+  argTypes: {
+    width: {
+      control: { type: 'range', min: 100, max: 600 },
+    },
+    height: {
+      control: { type: 'range', min: 100, max: 600 },
+    },
+    title: {
+      control: { type: 'text' },
+    },
+    isActive: {
+      control: { type: 'boolean' },
+    },
+  },
+  args: {
+    width: 166,
+    height: 48,
+    title: '기본 버튼',
+    isActive: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof TopNavBtn>;
+
+export const Default: Story = {
+  render: (args) => <TopNavBtn {...args} />,
+};


### PR DESCRIPTION
## 내용 설명
- top navigation의 경우에는 button으로 이루어져 있어, 공통 컴포넌트로 새로 구현했습니다.

## 구현 내용
- width, height, title, isActive, onClick으로 top_navigation_button을 조정할 수 있도록 했습니다.

## 스크린
<img width="190" alt="스크린샷 2023-09-19 오후 12 05 25" src="https://github.com/prgrms-fe-devcourse/FEDC4_FTA_JEESEOK/assets/44944877/ecb2a352-2ae3-4fd1-b920-078dc1d7c9d5">

<img width="190" alt="스크린샷 2023-09-19 오후 12 05 29" src="https://github.com/prgrms-fe-devcourse/FEDC4_FTA_JEESEOK/assets/44944877/5a56b041-f117-4aff-b218-7aaf54159a10">

## 장애물
- 없습니다.

## PR 포인트
- 필요없는 css가 있는지 살펴주시면 감사하겠습니다:)

## 참고 사항
- 없습니다.

## 궁금한 점
- width와 height를 고정시킬까했다가, 자유롭게 정할 수 있도록 매개변수에 넣도록 했는데 괜찮을까요?

close #166 