### PR TITLE
게시글 상세보기 페이지 변경

### DIFF
--- a/src/components/postDetail/PostDetail.tsx
+++ b/src/components/postDetail/PostDetail.tsx
@@ -24,7 +24,7 @@ interface postDetailProps {
   body: string;
   author: User;
   likeCount: number;
-  updateAt: string;
+  createAt: string;
   onLikeClick: () => void;
   isLike: boolean;
 }
@@ -35,7 +35,7 @@ const PostDetail = ({
   body,
   author,
   likeCount,
-  updateAt,
+  createAt,
   onLikeClick,
   isLike,
 }: postDetailProps) => {
@@ -61,7 +61,7 @@ const PostDetail = ({
                 center={true}
                 color={'#93A6C9'}
               >
-                {updateAt}
+                {createAt}
               </Text>
               <Tag>{channelName}</Tag>
             </TextWrapper>

--- a/src/pages/PostDetailPage/index.tsx
+++ b/src/pages/PostDetailPage/index.tsx
@@ -98,6 +98,7 @@ const PostDetailPage = () => {
     let title = '';
     let body = '';
     const likeCount = postDetailState?.likes.length;
+    const createAt = getDate(postDetailState.createdAt);
 
     if (titleBody.length > 0) {
       title = JSON.parse(titleBody)['title'];
@@ -112,9 +113,10 @@ const PostDetailPage = () => {
       likeCount,
       comments,
       updateAt,
+      createAt,
     };
   }, [postDetailState]);
-  const { channelName, title, body, author, likeCount, updateAt } =
+  const { channelName, title, body, author, likeCount, createAt } =
     postDetailData;
   return (
     <PostDetailContainer>
@@ -128,7 +130,7 @@ const PostDetailPage = () => {
         body={body}
         author={author}
         likeCount={likeCount}
-        updateAt={updateAt}
+        createAt={createAt}
         isLike={likeState.isLike}
         onLikeClick={toggleLike}
       />


### PR DESCRIPTION
## 내용 설명
게시글 상세보기 페이지 변경

## 구현 내용
기존에 updateAt으로 받아오던 날짜 데이터를 createAt으로 변경하였습니다.

## 스크린샷

## 장애물

## PR 포인트

## 참고 사항

## 궁금한 점
