### PR TITLE
댓글 입력창 높이 수정 및 폰트 변경 

### DIFF
--- a/src/components/postDetail/CommentInput.tsx
+++ b/src/components/postDetail/CommentInput.tsx
@@ -27,8 +27,13 @@ const CommentInput = ({
 
   const handleInputChange = (value: string) => {
     if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+      if (textareaRef.current.scrollHeight >= 34) {
+        textareaRef.current.style.height = 'auto';
+        textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
+      }
+      if (value === '') {
+        textareaRef.current.style.height = `20px`;
+      }
       onChange(value);
     }
   };

--- a/src/components/postDetail/commentStyle.ts
+++ b/src/components/postDetail/commentStyle.ts
@@ -34,6 +34,7 @@ export const CommentInputWrap = styled.div`
   border-bottom-left-radius: 40px;
   margin-left: 15px;
   padding: 5px 0 5px;
+  margin-top: 5px;
 `;
 
 export const CommentInputStyle = styled.textarea`
@@ -46,9 +47,13 @@ export const CommentInputStyle = styled.textarea`
     outline: none;
   }
   overflow: hidden;
+  height: 20px;
   width: 100%;
   line-height: 100%;
   font-size: 15px;
+  ::placeholder {
+    font-family: 'GangwonEdu_OTFBoldA';
+  }
 `;
 
 export const CommentButtonWrap = styled.div`


### PR DESCRIPTION
## 내용 설명
댓글 입력창 높이 수정 및 폰트 변경 

## 구현 내용
댓글 입력창 위치를 마진을 줘서 중앙으로 가게 수정하였으며 그에 따른 높이도 자동으로 조절되게 만들었습니다.
플레이스 홀더 글꼴이 적용되있지 않아 글꼴을 적용하였습니다.
## 스크린샷
<img width="449" alt="image" src="https://github.com/prgrms-fe-devcourse/FEDC4_FTA_JEESEOK/assets/106604926/e82333f0-e977-4e73-8fa1-4f0fde592043">

## 장애물

## PR 포인트

## 참고 사항

## 궁금한 점

close #214 