### PR TITLE
모바일에서 스크롤을 끝까지 할 시 배경이 잘리는 이슈 해결

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,45 +1,47 @@
 body {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    background: #f0f0f0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: #e6efff;
 }
 
 #root {
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
-    max-width: 425px;
-    margin-left: auto;
-    margin-right: auto;
-    background-color: #E6EFFF;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  max-width: 425px;
+  margin-left: auto;
+  margin-right: auto;
+  background-color: #e6efff;
 }
 
 @font-face {
-    font-family: 'MainFont';
-    src: url('./assets/font/PyeongChangPeace-Bold.ttf') format('opentype');
+  font-family: 'MainFont';
+  src: url('./assets/font/PyeongChangPeace-Bold.ttf') format('opentype');
 }
 
 @font-face {
-    font-family: 'Cafe24Font';
-    src: url('./assets/font/Cafe24Ssurround.ttf') format('opentype');
+  font-family: 'Cafe24Font';
+  src: url('./assets/font/Cafe24Ssurround.ttf') format('opentype');
 }
 
 @font-face {
-    font-family: 'GangwonEdu_OTFBoldA';
-    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2201-2@1.0/GangwonEdu_OTFBoldA.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
+  font-family: 'GangwonEdu_OTFBoldA';
+  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2201-2@1.0/GangwonEdu_OTFBoldA.woff')
+    format('woff');
+  font-weight: normal;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'ONE-Mobile-Title';
-    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2105_2@1.0/ONE-Mobile-Title.woff') format('woff');
-    font-weight: normal;
-    font-style: normal;
+  font-family: 'ONE-Mobile-Title';
+  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2105_2@1.0/ONE-Mobile-Title.woff')
+    format('woff');
+  font-weight: normal;
+  font-style: normal;
 }
 
 @font-face {
-    font-family: 'PyeongChangPeaceLight';
-    src: url('./assets/font/PyeongChangPeace-Light.ttf') format('opentype');
+  font-family: 'PyeongChangPeaceLight';
+  src: url('./assets/font/PyeongChangPeace-Light.ttf') format('opentype');
 }


### PR DESCRIPTION
## 내용 설명
index.css의 body 의 backgroud를 기존 #f0f0f0에서 #e6efff 로 변경하였습니다
## 궁금한 점 
이러면 root의 background-color 속성을 뺴도 되는게 아닌가 싶은데 일단 놔뒀습니다.
close #223