### PR TITLE
알림페이지 반응형으로 수정 및 버그 fix

### DIFF
--- a/src/pages/NotificationPage/NotificationCard.tsx
+++ b/src/pages/NotificationPage/NotificationCard.tsx
@@ -31,14 +31,17 @@ const NotificationCard = ({
 
   return !isLike || !isComment ? (
     <NotificationCardContainer onClick={handleNotificationCardClick}>
-      <CountContainer>
-        <UserName>{author.username}님이</UserName>
-        {like && <Text>회원님의 게시글에 공감합니다.</Text>}
-        {comment && <Text>회원님의 게시글에 댓글을 남겼습니다.</Text>}
-      </CountContainer>
-      <DateArea>
-        <CreatedDate>{getKoreaTimeFromNow(createdAt)}</CreatedDate>
-      </DateArea>
+      <MessageContainer>
+        {like && (
+          <Text>{author.username}님이 회원님의 게시글에 공감합니다.</Text>
+        )}
+        {comment && (
+          <Text>
+            {author.username}님이 회원님의 게시글에 댓글을 남겼습니다.
+          </Text>
+        )}
+      </MessageContainer>
+      <DateContainer>{getKoreaTimeFromNow(createdAt)}</DateContainer>
     </NotificationCardContainer>
   ) : (
     <></>
@@ -63,26 +66,20 @@ const NotificationCardContainer = styled.div`
   box-sizing: border-box;
 `;
 
-const CountContainer = styled.div`
-  display: flex;
-  gap: 15px;
+const MessageContainer = styled.div`
+  padding-left: 10px;
+  width: 75%;
+  overflow-x: hidden;
+  white-space: nowrap;
 `;
 
 const Text = styled.div`
-  width: 250px;
   position: relative;
   right: 10px;
-  flex-shrink: 0;
-  background-color: rgba(0, 0, 0, 0);
-  text-overflow: ellipsis;
-`;
-
-const DateArea = styled.div``;
-
-const CreatedDate = styled.div`
   background-color: rgba(0, 0, 0, 0);
 `;
 
-const UserName = styled.div`
-  background-color: rgba(0, 0, 0, 0);
+const DateContainer = styled.div`
+  overflow: hidden;
+  white-space: nowrap;
 `;

--- a/src/pages/NotificationPage/NotificationCard.tsx
+++ b/src/pages/NotificationPage/NotificationCard.tsx
@@ -26,10 +26,7 @@ const NotificationCard = ({
     }
   };
 
-  const isLike = !like;
-  const isComment = !comment;
-
-  return !isLike || !isComment ? (
+  return (
     <NotificationCardContainer onClick={handleNotificationCardClick}>
       <MessageContainer>
         {like && (
@@ -43,8 +40,6 @@ const NotificationCard = ({
       </MessageContainer>
       <DateContainer>{getKoreaTimeFromNow(createdAt)}</DateContainer>
     </NotificationCardContainer>
-  ) : (
-    <></>
   );
 };
 

--- a/src/pages/NotificationPage/index.tsx
+++ b/src/pages/NotificationPage/index.tsx
@@ -21,6 +21,8 @@ const NotificationPage = () => {
     setNotifications(isAuth.notifications);
   };
 
+  scrollTo(0, 0);
+
   useEffect(() => {
     getAuthCheck();
   }, [navigate]);

--- a/src/pages/NotificationPage/index.tsx
+++ b/src/pages/NotificationPage/index.tsx
@@ -8,10 +8,6 @@ import Header from '~/components/common/Header';
 import { Notification } from '~/types';
 import NotificationCardList from './NotificationCardList';
 
-const NotificationPageWrapper = styled.div`
-  width;100%
-  `;
-
 const NotificationPage = () => {
   const navigate = useNavigate();
   const [notifications, setNotifications] = useState<Notification[]>([]);
@@ -59,6 +55,11 @@ const NotificationPage = () => {
 };
 
 export default NotificationPage;
+
+const NotificationPageWrapper = styled.div`
+  max-width: 425px;
+  width: 100%;
+`;
 
 const NotificationPageBtn = styled(Button)`
   position: absolute;

--- a/src/pages/NotificationPage/index.tsx
+++ b/src/pages/NotificationPage/index.tsx
@@ -74,6 +74,7 @@ const NotificationPageBtn = styled(Button)`
   right: 20px;
   font-family: 'ONE-Mobile-Title';
   font-size: 16px;
+  white-space: nowrap;
   color: rgba(47, 47, 104, 0.8);
   background-color: rgba(252, 203, 243, 1);
   width: 120px;

--- a/src/pages/NotificationPage/index.tsx
+++ b/src/pages/NotificationPage/index.tsx
@@ -18,7 +18,12 @@ const NotificationPage = () => {
       navigate('/');
       return;
     }
-    setNotifications(isAuth.notifications);
+
+    setNotifications(
+      isAuth.notifications.filter(
+        (notification) => !!notification.like || !!notification.comment
+      )
+    );
   };
 
   scrollTo(0, 0);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -77,6 +77,7 @@ export interface Notification {
   post: string | null;
   follow?: string;
   comment?: Comment;
+  like?: Like;
   message?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## 내용 설명
- [x] 알림페이지 white-space:nowrap을 줘서 글자가 아래로 밀려 깨지지 않도록 작업했습니다
- [x]  scrollTo(0,0)을 사용해 다른페이지에서 스크롤을 하다가 알림페이지로 와도 맨 위로 올라가도록 작업했습니다.
- [x] api 문제로 인한 notification의 like,comment 값이 falsy하게 들어오면 이를 index단에서 필터링을 해주도록 했습니다. 따라서 빈 알림이 오더라도 렌더링 되지 않고, 알림전체 삭제 버튼도 활성화 되지 않습니다.
- [x] 알림페이지의 알림전체삭제 버튼도  white-space:nowrap을 줘서 꺠지지 않도록 했습니다.
- [x] 공통 type의 Notification 인터페이스에 like 값을 추가했습니다. 

close #206 