### PR TITLE
좋아요, 좋아요 취소시 게시글 상세정보 api를 다시 불러오던 문제 수정

### DIFF
--- a/src/pages/PostDetailPage/index.tsx
+++ b/src/pages/PostDetailPage/index.tsx
@@ -51,9 +51,21 @@ const PostDetailPage = () => {
     }
 
     if (isLike) {
-      await deleteLike({ likeId });
+      const data = await deleteLike({ likeId });
+      const likes = postDetailState.likes.filter(
+        (like) => like._id !== data._id
+      );
+      setPostDetailState((prevState) => ({
+        ...prevState,
+        likes: [...likes],
+      }));
     } else {
       const data = await postLike({ postId });
+      setPostDetailState((prevState) => ({
+        ...prevState,
+        likes: [...prevState.likes, data],
+      }));
+
       await postNotification({
         notificationType: LIKE,
         notificationTypeId: data._id,
@@ -61,8 +73,6 @@ const PostDetailPage = () => {
         postId: postId,
       });
     }
-
-    await postDetailApiCall();
   };
 
   //게시글 디테일 API 콜

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -55,7 +55,7 @@ export interface Post {
 export interface Like {
   _id: string;
   user: string;
-  post: Post;
+  post: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## 내용 설명
좋아요, 좋아요 취소시 게시글 상세정보 api를 다시 불러오던 문제 수정하였습니다.

## 참고 사항
#229 이슈에서 리펙터링 하기로한 리코일, 커스텀 훅을 사용하여 로직과 UI 분리는 새로 이슈를 파서 진행하겠습니다.

close #229 
