### PR TITLE
TagList 컴포넌트 디자인 수정

### DIFF
--- a/src/components/post/TagList/index.tsx
+++ b/src/components/post/TagList/index.tsx
@@ -10,25 +10,34 @@ const tags = [
 ] as const;
 
 interface TagListProps {
+  activeTag: string | undefined;
   onClick: (arg: string) => void;
 }
 
-const TagList = ({ onClick }: TagListProps) => {
+const TagList = ({ activeTag, onClick }: TagListProps) => {
+  const transformTag = (tag: string | undefined) => {
+    if (!tag) return 'all';
+    return tag.toLowerCase();
+  };
+
   return (
     <>
       <TagListContainer>
         {tags.map(([key, value]) => (
           <Tag
             key={key}
+            className={transformTag(activeTag) === key ? 'active' : ''}
             fontColor={'#F8FBFF'}
+            backgroundColor={'#D9E4FB'}
+            activeBackgroundColor={
+              'linear-gradient(45deg,#FCCBF3, #E8CBF4, #B6CCF9, #72CDFF)'
+            }
             borderRadius={'15px'}
             fontSize={'14px'}
             onClick={() => onClick(key)}
             style={{
               border: 'none',
               padding: '5px 15px',
-              background:
-                'linear-gradient(45deg,#FCCBF3, #E8CBF4, #B6CCF9, #72CDFF)',
               fontFamily: 'ONE-Mobile-Title',
             }}
           >

--- a/src/pages/PostPage/index.tsx
+++ b/src/pages/PostPage/index.tsx
@@ -83,7 +83,7 @@ const PostPage = () => {
   return (
     <>
       <Header isSearch />
-      <TagList onClick={handleTagClick} />
+      <TagList activeTag={currentTag || undefined} onClick={handleTagClick} />
       <PostCardList posts={posts} />
       {loading && offset === 0 ? <Loading isLoading /> : null}
       <ObserverContainer ref={observerRef}>


### PR DESCRIPTION
## 내용 설명
TagList 컴포넌트의 디자인을 수정했습니다.

## 구현 내용
- TagList 컴포넌트 디자인 수정
  - 활성화된 태그와 비활성화된 태그를 색생으로 구분

## 스크린샷
<img width="392" alt="스크린샷 2023-09-25 오후 5 07 46" src="https://github.com/prgrms-fe-devcourse/FEDC4_FTA_JEESEOK/assets/40534414/60ffe333-53db-4ac9-bffa-1047dbb79c7c">

close #278 